### PR TITLE
Refactor: Use mirrors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,11 @@ sudo: false
 
 php:
   - 5.6
-  - nightly
   - hhvm
   - hhvm-nightly
 
 matrix:
   allow_failures:
-    - php: nightly
-    - php: hhvm
     - php: hhvm-nightly
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Kinds
 [![Required HHVM 3.5+](https://raw.githubusercontent.com/xp-framework/web/master/static/hhvm-3_5plus.png)](http://hhvm.com/)
 [![Latest Stable Version](https://poser.pugx.org/xp-forge/kinds/version.png)](https://packagist.org/packages/xp-forge/kinds)
 
-Traits for common-used class kinds.
+Compile-time meta programming to make code more concise.
 
 Example
 -------

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Kinds
 [![Required HHVM 3.5+](https://raw.githubusercontent.com/xp-framework/web/master/static/hhvm-3_5plus.png)](http://hhvm.com/)
 [![Latest Stable Version](https://poser.pugx.org/xp-forge/kinds/version.png)](https://packagist.org/packages/xp-forge/kinds)
 
-Compile-time meta programming to make code more concise.
+Traits for compile-time metaprogramming.
 
 Example
 -------

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "~6.1",
-    "xp-forge/mirrors": "dev-master",
+    "xp-forge/mirrors": "~0.3",
     "php" : ">=5.6.0"
   },
   "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "~6.1",
-    "xp-forge/mirrors": "dev-infrastructure/sources",
+    "xp-forge/mirrors": "dev-master",
     "php" : ">=5.6.0"
   },
   "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "~6.1",
+    "xp-forge/mirrors": "dev-infrastructure/sources",
     "php" : ">=5.6.0"
   },
   "autoload" : {

--- a/src/main/php/lang/kind/Comparators.class.php
+++ b/src/main/php/lang/kind/Comparators.class.php
@@ -11,10 +11,10 @@ class Comparators extends Transformation {
   /**
    * Creates trait body
    *
-   * @param  lang.XPClass
+   * @param  lang.mirrors.TypeMirror $mirror
    * @return string
    */
-  protected function body($class) {
+  protected function body($mirror) {
     $unit= 'public function compareUsing($cmp, $field) {
       $local= $this->{$field};
       $other= $cmp->{$field};
@@ -25,8 +25,8 @@ class Comparators extends Transformation {
       }
     }';
 
-    foreach ($this->instanceFields($class) as $field) {
-      $n= $field->getName();
+    foreach ($this->instanceFields($mirror) as $field) {
+      $n= $field->name();
       $unit.= 'public static function by'.ucfirst($n).'() {
         return new \lang\kind\Comparison(function($a, $b) { return $a->compareUsing($b, \''.$n.'\'); });
       }';

--- a/src/main/php/lang/kind/Sortable.class.php
+++ b/src/main/php/lang/kind/Sortable.class.php
@@ -24,25 +24,19 @@ class Sortable extends Transformation {
   /**
    * Creates trait body
    *
-   * @param  lang.XPClass
+   * @param  lang.mirrors.TypeMirror $mirror
    * @return string
    */
-  protected function body($class) {
+  protected function body($mirror) {
     $compareTo= '';
-    $fields= $class->getFields();
-    foreach ($class->getTraits() as $trait) {
-      $fields= array_merge($fields, $trait->getFields());
-    }
-    foreach ($fields as $field) {
-      if (!($field->getModifiers() & MODIFIER_STATIC)) {
-        $n= $field->getName();
-        $compareTo.= 'if (method_exists($this->'.$n.', \'compareTo\')) {
-          $r= $this->'.$n.'->compareTo($cmp->'.$n.');
-        } else {
-          $r= ($this->'.$n.' === $cmp->'.$n.') ? 0 : ($this->'.$n.' < $cmp->'.$n.' ? -1 : 1);
-        }
-        if (0 !== $r) return $r;';
+    foreach ($this->instanceFields($mirror) as $field) {
+      $n= $field->name();
+      $compareTo.= 'if (method_exists($this->'.$n.', \'compareTo\')) {
+        $r= $this->'.$n.'->compareTo($cmp->'.$n.');
+      } else {
+        $r= ($this->'.$n.' === $cmp->'.$n.') ? 0 : ($this->'.$n.' < $cmp->'.$n.' ? -1 : 1);
       }
+      if (0 !== $r) return $r;';
     }
     return 'public function compareTo($cmp) { if ($cmp instanceof self) { '.$compareTo.'} return 0; }';
   }

--- a/src/main/php/lang/kind/Sortable.class.php
+++ b/src/main/php/lang/kind/Sortable.class.php
@@ -6,7 +6,7 @@
  * 
  * ```php
  * class Example extends \lang\Object {
- *   use \lang\kind\Sortable‹namespace\of\Example›;
+ *   use \lang\kind\Sortable»namespace\of\Example;
  *   private $firstName, $lastName;
  *
  *   public function __construct($firstName, $lastName) {

--- a/src/main/php/lang/kind/Transformation.class.php
+++ b/src/main/php/lang/kind/Transformation.class.php
@@ -24,7 +24,7 @@ abstract class Transformation extends \lang\Object {
    */
   protected function instanceFields($mirror) {
     $seen= [];
-    foreach ($mirror->fields()->of(Member::$INSTANCE) as $field) {
+    foreach ($mirror->fields()->of(Member::$INSTANCE | Member::$DECLARED) as $field) {
       $seen[$field->name()]= true;
       yield $field;
     }

--- a/src/main/php/lang/kind/Transformation.class.php
+++ b/src/main/php/lang/kind/Transformation.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\kind;
 
+use lang\mirrors\Member;
+
 /**
  * Compile-time transformation.
  */
@@ -8,29 +10,27 @@ abstract class Transformation extends \lang\Object {
   /**
    * Creates trait body
    *
-   * @param  lang.XPClass
+   * @param  lang.mirrors.TypeMirror
    * @return string
    */
-  protected abstract function body($class);
+  protected abstract function body($mirror);
 
   /**
    * Returns Field instances for all non-static fields of the given class
    * and the traits it uses.
    *
-   * @param  lang.XPClass
+   * @param  lang.mirrors.TypeMirror $mirror
    * @return php.Generator
    */
-  protected function instanceFields($class) {
+  protected function instanceFields($mirror) {
     $seen= [];
-    foreach ($class->getFields() as $field) {
-      if (!($field->getModifiers() & MODIFIER_STATIC)) {
-        $seen[$field->getName()]= true;
-        yield $field;
-      }
+    foreach ($mirror->fields()->of(Member::$INSTANCE) as $field) {
+      $seen[$field->name()]= true;
+      yield $field;
     }
-    foreach ($class->getTraits() as $trait) {
-      foreach ($trait->getFields() as $field) {
-        if (!($field->getModifiers() & MODIFIER_STATIC) && !isset($seen[$field->getName()])) {
+    foreach ($mirror->traits() as $trait) {
+      foreach ($trait->fields()->of(Member::$INSTANCE) as $field) {
+        if (!isset($seen[$field->name()])) {
           yield $field;
         }
       }
@@ -40,10 +40,10 @@ abstract class Transformation extends \lang\Object {
   /**
    * Transforms class
    *
-   * @param  lang.XPClass
+   * @param  lang.mirrors.TypeMirror
    * @return string
    */
-  public function transform($class) {
-    return $this->body($class);
+  public function transform($mirror) {
+    return $this->body($mirror);
   }
 }

--- a/src/main/php/lang/kind/ValueObject.class.php
+++ b/src/main/php/lang/kind/ValueObject.class.php
@@ -23,13 +23,13 @@ class ValueObject extends Transformation {
   /**
    * Creates trait body
    *
-   * @param  lang.XPClass
+   * @param  lang.mirrors.TypeMirror $mirror
    * @return string
    */
-  protected function body($class) {
+  protected function body($mirror) {
     $unit= '';
-    foreach ($this->instanceFields($class) as $field) {
-      $unit.= 'public function '.$field->getName().'() { return $this->'.$field->getName().'; }';
+    foreach ($this->instanceFields($mirror) as $field) {
+      $unit.= 'public function '.$field->name().'() { return $this->'.$field->name().'; }';
     }
 
     // equals()

--- a/src/main/php/lang/kind/ValueObject.class.php
+++ b/src/main/php/lang/kind/ValueObject.class.php
@@ -9,7 +9,7 @@
  * 
  * ```php
  * class Example extends \lang\Object {
- *   use \lang\kind\ValueObject‹namespace\of\Example›;
+ *   use \lang\kind\ValueObject»namespace\of\Example;
  *   private $name, $id;
  * }
  * ```

--- a/src/main/php/lang/kind/WithCreation.class.php
+++ b/src/main/php/lang/kind/WithCreation.class.php
@@ -6,7 +6,7 @@
  * 
  * ```php
  * class Example extends \lang\Object {
- *   use \lang\kind\WithCreation‹namespace\of\Example›;
+ *   use \lang\kind\With»Creationnamespace\of\Example;
  *   private $name, $id;
  *
  *   public function __construct($name, $id) {

--- a/src/main/php/lang/kind/WithCreation.class.php
+++ b/src/main/php/lang/kind/WithCreation.class.php
@@ -28,12 +28,12 @@ class WithCreation extends Transformation {
   /**
    * Creates trait body
    *
-   * @param  lang.XPClass
+   * @param  lang.mirrors.TypeMirror $mirror
    * @return string
    */
-  protected function body($class) {
+  protected function body($mirror) {
     return 'public static function with() {
-      return \lang\kind\InstanceCreation::of(new \lang\XPClass(\''.$class->literal().'\'));
+      return \lang\kind\InstanceCreation::of(new \lang\XPClass(\''.strtr($mirror->name(), '.', '\\').'\'));
     }';
   }
 }

--- a/src/main/php/module.xp
+++ b/src/main/php/module.xp
@@ -7,8 +7,8 @@ module xp-forge/kinds {
 
   /**
    * Initializes this module, registering class loader for compile-time
-   * transformations based on the classes inside the `lang.kind.transformation`
-   * package.
+   * transformations based on the classes extending the base class
+   * `lang.kind.Transformation`.
    */
   public function initialize() {
     spl_autoload_register(function($class) {

--- a/src/main/php/module.xp
+++ b/src/main/php/module.xp
@@ -1,6 +1,7 @@
 <?php namespace lang\kind;
 
-use lang\XPClass;
+use lang\mirrors\TypeMirror;
+use lang\mirrors\Sources;
 use lang\ClassFormatException;
 
 module xp-forge/kinds {
@@ -15,12 +16,15 @@ module xp-forge/kinds {
       if (false === $p= strpos($class, '»')) return false;
 
       $transformation= substr($class, 0, $p);
-      $type= new XPClass(substr($class, $p + 2));  // strlen("»")
+      $type= substr($class, $p + 2);   // strlen("»")
       if (!class_exists($transformation)) {
         throw new ClassFormatException('No compile-time transformation named '.strtr($transformation, '\\', '.'));
       }
 
-      $body= (new $transformation())->transform($type);
+      // Autoloaders not invoked correctly from within autoloading
+      if (null === Sources::$DEFAULT) Sources::__static();
+
+      $body= (new $transformation())->transform(new TypeMirror($type));
       $p= strrpos($class, '\\');
       $code= 'namespace '.substr($class, 0, $p).'; trait '.substr($class, $p + 1).' { '.$body.' }';
       eval($code);

--- a/src/main/php/module.xp
+++ b/src/main/php/module.xp
@@ -1,7 +1,6 @@
 <?php namespace lang\kind;
 
 use lang\mirrors\TypeMirror;
-use lang\mirrors\Sources;
 use lang\ClassFormatException;
 
 module xp-forge/kinds {
@@ -21,13 +20,16 @@ module xp-forge/kinds {
         throw new ClassFormatException('No compile-time transformation named '.strtr($transformation, '\\', '.'));
       }
 
-      // Autoloaders not invoked correctly from within autoloading
-      if (null === Sources::$DEFAULT) Sources::__static();
+      $cl= \xp::$cll;
+      \xp::$cll= 0;
 
       $body= (new $transformation())->transform(new TypeMirror($type));
       $p= strrpos($class, '\\');
       $code= 'namespace '.substr($class, 0, $p).'; trait '.substr($class, $p + 1).' { '.$body.' }';
       eval($code);
+
+      \xp::$cll= $cl;
+
       return true;
     });
   }


### PR DESCRIPTION
This PR uses the https://github.com/xp-forge/mirrors library instead of XP core reflection. This way, we get around the limitation that classes cannot be reflected in HHVM while they're being loaded - a core premise for our compile-time metaprogramming.

There is a dependency on xp-forge/mirrors#10
