### PR TITLE
Use new `use [Type]\including\[Transformation]` form

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,26 +17,31 @@ The `Identity` trait creates a value object wrapping around exactly one member. 
 ```php
 namespace example;
 
+use lang\kind\Identity;
+
 class Name extends \lang\Object {
-  use \lang\kind\Identity;
+  use Identity;
 
   public function personal() { return '~' === $this->value{0}; }
 }
 ```
 
-For situations where more logic than just "compiler-assisted copy&paste" is necessary, this library provides traits that expand dynamically based on the containing class at compile time. We use the syntax `name\of\Trait»name\of\containing\Class` for them, which we called *parametrized*. The symbol we use is the double closing [guillemet](http://en.wikipedia.org/wiki/Guillemet).
+For situations where more logic than just "compiler-assisted copy&paste" is necessary, this library provides traits that expand dynamically based on the containing class at compile time. We use the syntax `[Type]\including\[Transformation]` for them, which we called *parametrized*.
 
 The parametrized `ValueObject` trait creates accessors for all instance members and ensures `equals()` and `toString()` are implemented for this value object in a generic way, using the util.Objects class to compare the objects memberwise. All we need to do is to add a constructor (*this is not generated as we might want to add default values and custom verification logic*).
 
 ```php
 namespace example;
 
+use lang\kind\ValueObject;
+
 class Type extends \lang\Enum {
   public static $OPEN, $CLOSED;
 }
 
 class Wall extends \lang\Object {
-  use \lang\kind\ValueObject»example\Wall;
+  use Wall\including\ValueObject;
+
   private $name, $type, $posts;
 
   public function __construct(Name $name, Type $type, Posts $posts) {
@@ -52,8 +57,10 @@ The `ListOf` trait creates a list of elements which can be accessed by their off
 ```php
 namespace example;
 
+use lang\kind\ListOf;
+
 class Posts extends \lang\Object implements \IteratorAggregate {
-  use \lang\kind\ListOf;
+  use ListOf;
 }
 ```
 
@@ -64,10 +71,15 @@ The `Comparators` trait adds static `by[Member]` methods returning util.Comparat
 ```php
 namespace example;
 
+use lang\kind\ValueObject;
+use lang\kind\WithCreation;
+use lang\kind\Comparators;
+
 class Post extends \lang\Object {
-  use \lang\kind\ValueObject»example\Post;
-  use \lang\kind\WithCreation»example\Post;
-  use \lang\kind\Comparators»example\Post;
+  use Wall\including\ValueObject;
+  use Wall\including\WithCreation;
+  use Wall\including\Comparators;
+
   private $author, $text, $date;
 
   public function __construct($author, $text, Date $date) {
@@ -83,8 +95,10 @@ The `ListIndexedBy` trait creates a list of elements which can be queried by nam
 ```php
 namespace example;
 
+use lang\kind\ListIndexedBy;
+
 class Walls extends \lang\Object implements \IteratorAggregate {
-  use \lang\kind\ListIndexedBy;
+  use ListIndexedBy;
 
   protected function index($wall) { return $wall->name()->value(); }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^6.1",
-    "xp-forge/mirrors": "^0.5",
+    "xp-forge/mirrors": "^0.5.1",
     "php" : ">=5.6.0"
   },
   "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
   "description" : "Type kinds",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "~6.1",
-    "xp-forge/mirrors": "~0.3",
+    "xp-framework/core": "^6.1",
+    "xp-forge/mirrors": "^0.5",
     "php" : ">=5.6.0"
   },
   "autoload" : {

--- a/src/main/php/module.xp
+++ b/src/main/php/module.xp
@@ -12,23 +12,20 @@ module xp-forge/kinds {
    */
   public function initialize() {
     spl_autoload_register(function($class) {
-      if (false === $p= strpos($class, '»')) return false;
-
-      $transformation= substr($class, 0, $p);
-      $type= substr($class, $p + 2);   // strlen("»")
-      if (!class_exists($transformation)) {
-        throw new ClassFormatException('No compile-time transformation named '.strtr($transformation, '\\', '.'));
-      }
+      if (false === $p= strpos($class, '\\including\\')) return false;
 
       $cl= \xp::$cll;
       \xp::$cll= 0;
+      try {
+        $mirror= new TypeMirror(substr($class, 0, $p));
+        $transform= $mirror->resolve(substr($class, $p + 11));   // strlen('\\including\\')
 
-      $body= (new $transformation())->transform(new TypeMirror($type));
-      $p= strrpos($class, '\\');
-      $code= 'namespace '.substr($class, 0, $p).'; trait '.substr($class, $p + 1).' { '.$body.' }';
-      eval($code);
-
-      \xp::$cll= $cl;
+        $body= $transform->constructor()->newInstance()->transform($mirror);
+        $code= 'namespace '.substr($class, 0, $p + 10).'; trait '.substr($class, $p + 11).' { '.$body.' }';
+        eval($code);
+      } finally {
+        \xp::$cll= $cl;
+      }
 
       return true;
     });

--- a/src/test/php/lang/kind/unittest/Author.class.php
+++ b/src/test/php/lang/kind/unittest/Author.class.php
@@ -1,11 +1,15 @@
 <?php namespace lang\kind\unittest;
 
+use lang\kind\ValueObject;
+use lang\kind\WithCreation;
+
 /**
  * Used by InstanceCreationTest
  */
 class Author extends \lang\Object {
-  use \lang\kind\ValueObject»lang\kind\unittest\Author;
-  use \lang\kind\WithCreation»lang\kind\unittest\Author;
+  use Author\including\ValueObject;
+  use Author\including\WithCreation;
+
   private $name;
 
   /**

--- a/src/test/php/lang/kind/unittest/Book.class.php
+++ b/src/test/php/lang/kind/unittest/Book.class.php
@@ -1,13 +1,16 @@
 <?php namespace lang\kind\unittest;
 
 use util\Objects;
+use lang\kind\ValueObject;
+use lang\kind\WithCreation;
 
 /**
  * Used by InstanceCreationTest
  */
 class Book extends \lang\Object {
-  use \lang\kind\ValueObject»lang\kind\unittest\Book;
-  use \lang\kind\WithCreation»lang\kind\unittest\Book;
+  use Book\including\ValueObject;
+  use Book\including\WithCreation;
+
   private $name, $author, $isbn;
 
   /**

--- a/src/test/php/lang/kind/unittest/Coin.class.php
+++ b/src/test/php/lang/kind/unittest/Coin.class.php
@@ -5,5 +5,4 @@
  */
 class Coin extends \lang\Enum {
   public static $PENNY= 1, $NICKEL= 5, $DIME= 10, $QUARTER= 25;
-
 }

--- a/src/test/php/lang/kind/unittest/Isbn.class.php
+++ b/src/test/php/lang/kind/unittest/Isbn.class.php
@@ -1,13 +1,17 @@
 <?php namespace lang\kind\unittest;
 
+use lang\kind\ValueObject;
+use lang\kind\WithCreation;
+
 /**
  * Used by InstanceCreationTest
  */
 class Isbn extends \lang\Object {
   const EAN13 = 13;
 
-  use \lang\kind\ValueObject»lang\kind\unittest\Isbn;
-  use \lang\kind\WithCreation»lang\kind\unittest\Isbn;
+  use Isbn\including\ValueObject;
+  use Isbn\including\WithCreation;
+
   private $number, $type;
 
   /**

--- a/src/test/php/lang/kind/unittest/Named.class.php
+++ b/src/test/php/lang/kind/unittest/Named.class.php
@@ -1,11 +1,14 @@
 <?php namespace lang\kind\unittest;
 
+use lang\kind\Identity;
+use lang\kind\Sortable;
+
 /**
  * Used as fixture in the "IdentityTest" and "SortableTest" classes
  */
 class Named extends \lang\Object {
-  use \lang\kind\Identity { value as name; }
-  use \lang\kind\Sortable»lang\kind\unittest\Named;
+  use Identity { value as name; }
+  use Named\including\Sortable;
 
   /** @return bool */
   public function isEmpty() { return '' === $this->value; }

--- a/src/test/php/lang/kind/unittest/Person.class.php
+++ b/src/test/php/lang/kind/unittest/Person.class.php
@@ -1,12 +1,16 @@
 <?php namespace lang\kind\unittest;
 
+use \lang\kind\ValueObject;
+use \lang\kind\Sortable;
+use \lang\kind\Comparators;
+
 /**
  * Used by SortableTest
  */
 class Person extends \lang\Object {
-  use \lang\kind\ValueObject»lang\kind\unittest\Person;
-  use \lang\kind\Sortable»lang\kind\unittest\Person;
-  use \lang\kind\Comparators»lang\kind\unittest\Person {
+  use Person\including\ValueObject;
+  use Person\including\Sortable;
+  use Person\including\Comparators {
     byBorn as byBirthDate;
   }
 

--- a/src/test/php/lang/kind/unittest/Post.class.php
+++ b/src/test/php/lang/kind/unittest/Post.class.php
@@ -1,13 +1,16 @@
 <?php namespace lang\kind\unittest;
 
 use util\Date;
+use lang\kind\ValueObject;
+use lang\kind\Comparators;
 
 /**
  * Used as fixture in the "ValueObjectTest" class
  */
 class Post extends \lang\Object {
-  use \lang\kind\ValueObject»lang\kind\unittest\Post;
-  use \lang\kind\Comparators»lang\kind\unittest\Post;
+  use Post\including\ValueObject;
+  use Post\including\Comparators;
+
   private $author, $text, $date;
 
   public function __construct($author, $text, Date $date) {

--- a/src/test/php/lang/kind/unittest/Tests.class.php
+++ b/src/test/php/lang/kind/unittest/Tests.class.php
@@ -1,10 +1,18 @@
 <?php namespace lang\kind\unittest;
 
+use lang\kind\ListIndexedBy;
+
 /**
  * Used as fixture in the "ListIndexedByTest" class
  */
 class Tests extends \lang\Object implements \IteratorAggregate {
-  use \lang\kind\ListIndexedBy;
+  use ListIndexedBy;
 
+  /**
+   * Calculate index
+   *
+   * @param  unittest.TestCase $test
+   * @return string
+   */
   protected function index($test) { return $test->getName(); }
 }

--- a/src/test/php/lang/kind/unittest/Wall.class.php
+++ b/src/test/php/lang/kind/unittest/Wall.class.php
@@ -1,10 +1,13 @@
 <?php namespace lang\kind\unittest;
 
+use lang\kind\ValueObject;
+
 /**
  * Used as fixture in the "ValueObjectTest" class
  */
 class Wall extends \lang\Object {
-  use \lang\kind\ValueObject»lang\kind\unittest\Wall;
+  use Wall\including\ValueObject;
+
   private $name, $type, $posts;
 
   /**

--- a/src/test/php/lang/kind/unittest/Walls.class.php
+++ b/src/test/php/lang/kind/unittest/Walls.class.php
@@ -1,9 +1,10 @@
 <?php namespace lang\kind\unittest;
 
+use lang\kind\ListOf;
+
 /**
  * Used as fixture in the "ListOfTest" class
  */
 class Walls extends \lang\Object implements \IteratorAggregate {
-  use \lang\kind\ListOf;
-
+  use ListOf;
 }


### PR DESCRIPTION
Implements functionality suggested in #2 

_Does not include renaming library and namespace to `partial`!_
