### PR TITLE
Constructor transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,17 +121,17 @@ class Wall extends \lang\Object {
 </pre>
 </td></tr></table>
 
-If the constructor consists solely of assignments, you can include the `WithConstructor` trait and remove it. The parameters will be declared in the order the fields are declared: top to bottom, left to right in the source code.
+If the constructor consists solely of assignments, you can include the `Constructor` trait and remove it. The parameters will be declared in the order the fields are declared: top to bottom, left to right in the source code.
 
 <table><tr><td width="360" valign="top">
 Writing this:
 <pre lang="php">
 namespace example;
 
-use lang\partial\WithConstructor;
+use lang\partial\Constructor;
 
 class Author extends \lang\Object {
-  use Autor\including\WithConstructor;
+  use Autor\including\Constructor;
 
   private $handle, $name;
 }

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ namespace example;
 use lang\partial\Constructor;
 
 class Author extends \lang\Object {
-  use Autor\including\Constructor;
+  use Author\including\Constructor;
 
   private $handle, $name;
 }

--- a/README.md
+++ b/README.md
@@ -121,6 +121,38 @@ class Wall extends \lang\Object {
 </pre>
 </td></tr></table>
 
+If the constructor consists solely of assignments, you can include the `Constructor` trait and remove it. The parameters will be declared in the order the fields are declared: top to bottom, left to right in the source code.
+
+<table><tr><td width="360" valign="top">
+Writing this:
+<pre lang="php">
+namespace example;
+
+use lang\partial\Constructor;
+
+class Author extends \lang\Object {
+  use Autor\including\Constructor;
+
+  private $handle, $name;
+}
+</pre>
+</td><td width="360" valign="top">
+...is equivalent to:
+<pre lang="php">
+namespace example;
+
+class Author extends \lang\Object {
+  private $handle, $name;
+
+  public function __construct($handle, $name) {
+    $this->handle= $handle;
+    $this->name= $name;
+  }
+}
+</pre>
+</td></tr></table>
+
+
 The `ListOf` trait creates a list of elements which can be accessed by their offset, iterated by `foreach`, and offers `equals()` and `toString()` default implementations.
 
 <table><tr><td width="360" valign="top">

--- a/README.md
+++ b/README.md
@@ -121,17 +121,17 @@ class Wall extends \lang\Object {
 </pre>
 </td></tr></table>
 
-If the constructor consists solely of assignments, you can include the `Constructor` trait and remove it. The parameters will be declared in the order the fields are declared: top to bottom, left to right in the source code.
+If the constructor consists solely of assignments, you can include the `WithConstructor` trait and remove it. The parameters will be declared in the order the fields are declared: top to bottom, left to right in the source code.
 
 <table><tr><td width="360" valign="top">
 Writing this:
 <pre lang="php">
 namespace example;
 
-use lang\partial\Constructor;
+use lang\partial\WithConstructor;
 
 class Author extends \lang\Object {
-  use Autor\including\Constructor;
+  use Autor\including\WithConstructor;
 
   private $handle, $name;
 }
@@ -151,7 +151,6 @@ class Author extends \lang\Object {
 }
 </pre>
 </td></tr></table>
-
 
 The `ListOf` trait creates a list of elements which can be accessed by their offset, iterated by `foreach`, and offers `equals()` and `toString()` default implementations.
 

--- a/src/main/php/lang/partial/Constructor.class.php
+++ b/src/main/php/lang/partial/Constructor.class.php
@@ -1,0 +1,47 @@
+<?php namespace lang\partial;
+
+/**
+ * Compile-time transformation which generates a constructor.
+ * 
+ * ```php
+ * use lang\partial\Sortable;
+ *
+ * class Example extends \lang\Object {
+ *   use Example\including\Constructor;
+ *
+ *   private $firstName, $lastName;
+ * }
+ * ```
+ *
+ * This generates the following code:
+ *
+ * ```php
+ * public function __construct($firstName, $lastName) {
+ *   $this->firstName= $firstName;
+ *   $this->lastName= $lastName;
+ * }
+ * ```
+ *
+ * The parameters appear in the order the fields are declared: top to bottom,
+ * left to right inside the source code.
+ *
+ * @test  xp://lang.partial.unittest.ConstructorTest
+ */
+class Constructor extends Transformation {
+
+  /**
+   * Creates trait body
+   *
+   * @param  lang.mirrors.TypeMirror $mirror
+   * @return string
+   */
+  protected function body($mirror) {
+    $signature= $assignments= '';
+    foreach ($this->instanceFields($mirror) as $field) {
+      $n= $field->name();
+      $signature.= ', $'.$n;
+      $assignments.= '$this->'.$n.'= $'.$n.';';
+    }
+    return 'public function __construct('.substr($signature, 2).') { '.$assignments.' }';
+  }
+}

--- a/src/main/php/lang/partial/Constructor.class.php
+++ b/src/main/php/lang/partial/Constructor.class.php
@@ -4,10 +4,10 @@
  * Compile-time transformation which generates a constructor.
  * 
  * ```php
- * use lang\partial\WithConstructor;
+ * use lang\partial\Constructor;
  *
  * class Example extends \lang\Object {
- *   use Example\including\WithConstructor;
+ *   use Example\including\Constructor;
  *
  *   private $firstName, $lastName;
  * }
@@ -27,7 +27,7 @@
  *
  * @test  xp://lang.partial.unittest.ConstructorTest
  */
-class WithConstructor extends Transformation {
+class Constructor extends Transformation {
 
   /**
    * Creates trait body

--- a/src/main/php/lang/partial/WithConstructor.class.php
+++ b/src/main/php/lang/partial/WithConstructor.class.php
@@ -4,10 +4,10 @@
  * Compile-time transformation which generates a constructor.
  * 
  * ```php
- * use lang\partial\Sortable;
+ * use lang\partial\WithConstructor;
  *
  * class Example extends \lang\Object {
- *   use Example\including\Constructor;
+ *   use Example\including\WithConstructor;
  *
  *   private $firstName, $lastName;
  * }
@@ -27,7 +27,7 @@
  *
  * @test  xp://lang.partial.unittest.ConstructorTest
  */
-class Constructor extends Transformation {
+class WithConstructor extends Transformation {
 
   /**
    * Creates trait body

--- a/src/test/php/lang/partial/unittest/ConstructorTest.class.php
+++ b/src/test/php/lang/partial/unittest/ConstructorTest.class.php
@@ -1,0 +1,19 @@
+<?php namespace lang\partial\unittest;
+
+class ConstructorTest extends \unittest\TestCase {
+
+  #[@test]
+  public function firstName() {
+    $this->assertEquals('Timm', (new Person('Timm', 'Test', 1977))->firstName());
+  }
+
+  #[@test]
+  public function lastName() {
+    $this->assertEquals('Test', (new Person('Timm', 'Test', 1977))->lastName());
+  }
+
+  #[@test]
+  public function born() {
+    $this->assertEquals(1977, (new Person('Timm', 'Test', 1977))->born());
+  }
+}

--- a/src/test/php/lang/partial/unittest/Person.class.php
+++ b/src/test/php/lang/partial/unittest/Person.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\partial\unittest;
 
 use lang\partial\ValueObject;
-use lang\partial\Constructor;
+use lang\partial\WithConstructor;
 use lang\partial\Sortable;
 use lang\partial\Comparators;
 
@@ -10,7 +10,7 @@ use lang\partial\Comparators;
  */
 class Person extends \lang\Object {
   use Person\including\ValueObject;
-  use Person\including\Constructor;
+  use Person\including\WithConstructor;
   use Person\including\Sortable;
   use Person\including\Comparators {
     byBorn as byBirthDate;

--- a/src/test/php/lang/partial/unittest/Person.class.php
+++ b/src/test/php/lang/partial/unittest/Person.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\partial\unittest;
 
 use lang\partial\ValueObject;
+use lang\partial\Constructor;
 use lang\partial\Sortable;
 use lang\partial\Comparators;
 
@@ -9,23 +10,11 @@ use lang\partial\Comparators;
  */
 class Person extends \lang\Object {
   use Person\including\ValueObject;
+  use Person\including\Constructor;
   use Person\including\Sortable;
   use Person\including\Comparators {
     byBorn as byBirthDate;
   }
 
   private $firstName, $lastName, $born;
-
-  /**
-   * Creates a new author
-   *
-   * @param  string $firstName
-   * @param  string $lastName
-   * @param  int $born
-   */
-  public function __construct($firstName, $lastName, $born) {
-    $this->firstName= $firstName;
-    $this->lastName= $lastName;
-    $this->born= $born;
-  }
 }

--- a/src/test/php/lang/partial/unittest/Person.class.php
+++ b/src/test/php/lang/partial/unittest/Person.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\partial\unittest;
 
 use lang\partial\ValueObject;
-use lang\partial\WithConstructor;
+use lang\partial\Constructor;
 use lang\partial\Sortable;
 use lang\partial\Comparators;
 
@@ -10,7 +10,7 @@ use lang\partial\Comparators;
  */
 class Person extends \lang\Object {
   use Person\including\ValueObject;
-  use Person\including\WithConstructor;
+  use Person\including\Constructor;
   use Person\including\Sortable;
   use Person\including\Comparators {
     byBorn as byBirthDate;


### PR DESCRIPTION
If the constructor consists solely of assignments, you can include the `Constructor` trait and remove it. The parameters will be declared in the order the fields are declared: top to bottom, left to right in the source code.

<table><tr><td width="360" valign="top">
Writing this:
<pre lang="php">
namespace example;

use lang\partial\Constructor;

class Author extends \lang\Object {
  use Author\including\Constructor;

  private $handle, $name;
}
</pre>
</td><td width="360" valign="top">
...is equivalent to:
<pre lang="php">
namespace example;

class Author extends \lang\Object {
  private $handle, $name;

  public function __construct($handle, $name) {
    $this->handle= $handle;
    $this->name= $name;
  }
}
</pre>
</td></tr></table>
