### PR TITLE
Handle transformations and regular traits consistently...

### DIFF
--- a/src/main/php/module.xp
+++ b/src/main/php/module.xp
@@ -4,6 +4,7 @@ use lang\mirrors\TypeMirror;
 use lang\ClassFormatException;
 
 module xp-forge/partial {
+  private static $verbs= ['\\including\\', '\\is\\'];
 
   /**
    * Initializes this module, registering class loader for compile-time
@@ -12,22 +13,29 @@ module xp-forge/partial {
    */
   public function initialize() {
     spl_autoload_register(function($class) {
-      if (false === $p= strpos($class, '\\including\\')) return false;
+      foreach (self::$verbs as $verb) {
+        if ($p= strpos($class, $verb)) {
+          $cl= \xp::$cll;
+          $l= strlen($verb);
+          \xp::$cll= 0;
+          try {
+            $mirror= new TypeMirror(substr($class, 0, $p));
+            $transform= $mirror->resolve(substr($class, $p + $l));
 
-      $cl= \xp::$cll;
-      \xp::$cll= 0;
-      try {
-        $mirror= new TypeMirror(substr($class, 0, $p));
-        $transform= $mirror->resolve(substr($class, $p + 11));   // strlen('\\including\\')
-
-        $body= $transform->constructor()->newInstance()->transform($mirror);
-        $code= 'namespace '.substr($class, 0, $p + 10).'; trait '.substr($class, $p + 11).' { '.$body.' }';
-        eval($code);
-      } finally {
-        \xp::$cll= $cl;
+            if ($transform->kind()->isTrait()) {
+              class_alias(strtr($transform->name(), '.', '\\'), $class);
+            } else {
+              $body= $transform->constructor()->newInstance()->transform($mirror);
+              $code= 'namespace '.substr($class, 0, $p + 10).'; trait '.substr($class, $p + $l).' { '.$body.' }';
+              eval($code);
+            }
+          } finally {
+            \xp::$cll= $cl;
+          }
+          return true;
+        }
       }
-
-      return true;
+      return false;
     });
   }
 }

--- a/src/main/php/module.xp
+++ b/src/main/php/module.xp
@@ -4,7 +4,7 @@ use lang\mirrors\TypeMirror;
 use lang\ClassFormatException;
 
 module xp-forge/partial {
-  private static $verbs= ['\\including\\', '\\is\\'];
+  private static $verbs= ['\\with\\', '\\is\\', '\\including\\'];
 
   /**
    * Initializes this module, registering class loader for compile-time

--- a/src/test/php/lang/partial/unittest/Named.class.php
+++ b/src/test/php/lang/partial/unittest/Named.class.php
@@ -7,7 +7,7 @@ use lang\partial\Sortable;
  * Used as fixture in the "IdentityTest" and "SortableTest" classes
  */
 class Named extends \lang\Object {
-  use Identity { value as name; }
+  use Named\is\Identity { value as name; }
   use Named\including\Sortable;
 
   /** @return bool */

--- a/src/test/php/lang/partial/unittest/Tests.class.php
+++ b/src/test/php/lang/partial/unittest/Tests.class.php
@@ -6,7 +6,7 @@ use lang\partial\ListIndexedBy;
  * Used as fixture in the "ListIndexedByTest" class
  */
 class Tests extends \lang\Object implements \IteratorAggregate {
-  use ListIndexedBy;
+  use Tests\is\ListIndexedBy;
 
   /**
    * Calculate index

--- a/src/test/php/lang/partial/unittest/Walls.class.php
+++ b/src/test/php/lang/partial/unittest/Walls.class.php
@@ -6,5 +6,5 @@ use lang\partial\ListOf;
  * Used as fixture in the "ListOfTest" class
  */
 class Walls extends \lang\Object implements \IteratorAggregate {
-  use ListOf;
+  use Walls\is\ListOf;
 }


### PR DESCRIPTION
...from a user perspective.

At the same time, allow "is" and "with" (next to "including" for BC) to circumvent awkward feeling formulations. See https://github.com/xp-forge/partial/issues/10#issuecomment-143543442
### Example 1

``` php
use lang\partial\Identity;
use lang\partial\Comparators;

class Name extends \lang\Object {
  use Name\is\Identity;
  use Name\with\Comparators;

}
```
### Example 2

``` php
use lang\partial\ListOf;

class Customers extends \lang\Object {
  use Customers\is\ListOf;

}
```
### Implementation

The inner workings to achieve consistent handling are the special case handling of traits:

``` php
if ($transform->kind()->isTrait()) {
  class_alias(strtr($transform->name(), '.', '\\'), $class);
} else {
  $body= $transform->constructor()->newInstance()->transform($mirror);
  $code= // Generation omitted for brevitiy
  eval($code);
}
```

_Note: `Use Identity` inside the class will continue to work as before!_
