### PR TITLE
Add types to generated members

### DIFF
--- a/src/main/php/lang/partial/Accessors.class.php
+++ b/src/main/php/lang/partial/Accessors.class.php
@@ -17,6 +17,7 @@ class Accessors extends Transformation {
   protected function body($mirror) {
     $unit= '';
     foreach ($this->instanceFields($mirror) as $field) {
+      $unit.= '/** @return '.$field->type().' */';
       $unit.= 'public function '.$field->name().'() { return $this->'.$field->name().'; }';
     }
     return $unit;

--- a/src/main/php/lang/partial/Builder.class.php
+++ b/src/main/php/lang/partial/Builder.class.php
@@ -34,7 +34,7 @@ class Builder extends Transformation {
    * @return string
    */
   protected function body($mirror) {
-    return 'public static function with() {
+    return '/** @return lang.partial.InstanceCreation */ public static function with() {
       return \lang\partial\InstanceCreation::of(new \lang\XPClass(\''.strtr($mirror->name(), '.', '\\').'\'));
     }';
   }

--- a/src/main/php/lang/partial/Comparators.class.php
+++ b/src/main/php/lang/partial/Comparators.class.php
@@ -27,7 +27,7 @@ class Comparators extends Transformation {
 
     foreach ($this->instanceFields($mirror) as $field) {
       $n= $field->name();
-      $unit.= 'public static function by'.ucfirst($n).'() {
+      $unit.= '/** @return lang.partial.Comparison */ public static function by'.ucfirst($n).'() {
         return new \lang\partial\Comparison(function($a, $b) { return $a->compareUsing($b, \''.$n.'\'); });
       }';
     }

--- a/src/main/php/lang/partial/CompareTo.class.php
+++ b/src/main/php/lang/partial/CompareTo.class.php
@@ -22,6 +22,9 @@ class CompareTo extends Transformation {
       $n= $field->name();
       $compareTo.= 'if (0 !== $r= \util\Objects::compare($this->'.$n.', $cmp->'.$n.')) return $r;';
     }
-    return 'public function compareTo($cmp) { if ($cmp instanceof self) { '.$compareTo.' return 0; } return 1; }';
+    return 
+      "/**\n * @param var\n * @return int\n*/\n".
+      'public function compareTo($cmp) { if ($cmp instanceof self) { '.$compareTo.' return 0; } return 1; }'
+    ;
   }
 }

--- a/src/main/php/lang/partial/Constructor.class.php
+++ b/src/main/php/lang/partial/Constructor.class.php
@@ -36,12 +36,13 @@ class Constructor extends Transformation {
    * @return string
    */
   protected function body($mirror) {
-    $signature= $assignments= '';
+    $signature= $assignments= $types= '';
     foreach ($this->instanceFields($mirror) as $field) {
       $n= $field->name();
+      $types.= ' * @param '.$field->type()."\n";
       $signature.= ', $'.$n;
       $assignments.= '$this->'.$n.'= $'.$n.';';
     }
-    return 'public function __construct('.substr($signature, 2).') { '.$assignments.' }';
+    return "/**\n".$types."*/\npublic function __construct(".substr($signature, 2).') { '.$assignments.' }';
   }
 }

--- a/src/main/php/lang/partial/Equals.class.php
+++ b/src/main/php/lang/partial/Equals.class.php
@@ -21,6 +21,9 @@ class Equals extends Transformation {
       $n= $field->name();
       $compare.= '&& \util\Objects::equal($this->'.$n.', $cmp->'.$n.')';
     }
-    return 'public function equals($cmp) { return $cmp instanceof self '.$compare.'; }';
+    return
+      "/**\n * @param var\n * @return bool\n*/\n".
+      'public function equals($cmp) { return $cmp instanceof self '.$compare.'; }'
+    ;
   }
 }

--- a/src/main/php/lang/partial/HashCode.class.php
+++ b/src/main/php/lang/partial/HashCode.class.php
@@ -23,9 +23,10 @@ class HashCode extends Transformation {
     }
 
     if ('' === $hashes) {
-      return 'public function hashCode() { return spl_object_hash($this); }';
+      $implementation= 'return spl_object_hash($this);';
     } else {
-      return 'public function hashCode() { return md5(nameof($this)'.$hashes.'); }';
+      $implementation= 'return md5(nameof($this)'.$hashes.');';
     }
+    return '/** @return string */ public function hashCode() { '.$implementation.' }';
   }
 }

--- a/src/main/php/lang/partial/InstanceCreation.class.php
+++ b/src/main/php/lang/partial/InstanceCreation.class.php
@@ -10,11 +10,11 @@ abstract class InstanceCreation extends \lang\Object {
   /**
    * Creates a new instance creation fluent interface for a given class
    *
-   * @param  var $class Either a lang.XPClass or a string
+   * @param  lang.mirrors.TypeMirror|lang.XPClass|string $type
    * @return lang.XPClass
    */
-  public static final function typeOf($class) {
-    $mirror= new TypeMirror($class);
+  public static final function typeOf($type) {
+    $mirror= $type instanceof TypeMirror ? $type : new TypeMirror($type);
     $type= $mirror->name();
 
     if (!isset(self::$creations[$type])) {
@@ -35,6 +35,7 @@ abstract class InstanceCreation extends \lang\Object {
         } else {
           $setters.= 'public $'.$name.';';
         }
+        $setters.= '/** @param '.$parameter->type().' */';
         $setters.= 'public function '.$name.'($value) { $this->'.$name.'= $value; return $this; }';
         $args.= ', $this->'.$name;
       }

--- a/src/main/php/lang/partial/InstanceCreation.class.php
+++ b/src/main/php/lang/partial/InstanceCreation.class.php
@@ -41,6 +41,7 @@ abstract class InstanceCreation extends \lang\Object {
       }
 
       self::$creations[$type]= ClassLoader::defineClass($type.'Creation', 'lang.partial.InstanceCreation', [], '{
+        /** @return '.$mirror->name().' */
         public function create() { return new \\'.$mirror->reflect->name.'('.substr($args, 2).'); }
         '.$setters.'
       }');

--- a/src/main/php/lang/partial/InstanceCreation.class.php
+++ b/src/main/php/lang/partial/InstanceCreation.class.php
@@ -35,7 +35,7 @@ abstract class InstanceCreation extends \lang\Object {
         } else {
           $setters.= 'public $'.$name.';';
         }
-        $setters.= '/** @param '.$parameter->type().' */';
+        $setters.= "/**\n * @param ".$parameter->type()."\n * @return self\n*/";
         $setters.= 'public function '.$name.'($value) { $this->'.$name.'= $value; return $this; }';
         $args.= ', $this->'.$name;
       }

--- a/src/main/php/lang/partial/ToString.class.php
+++ b/src/main/php/lang/partial/ToString.class.php
@@ -23,11 +23,12 @@ class ToString extends Transformation {
     }
 
     if ('' === $stringOf) {
-      return 'public function toString() { return nameof($this)."@(#".$this->hashCode().")"; }';
+      $implementation= 'return nameof($this)."@(#".$this->hashCode().")";';
     } else if (0 === $i) {
-      return 'public function toString() { return nameof($this)."@(".\xp::stringOf($this->'.$n.').")"; }';
+      $implementation= 'return nameof($this)."@(".\xp::stringOf($this->'.$n.').")";';
     } else {
-      return 'public function toString() { return nameof($this)."@[\n"'.$stringOf.'."]"; }';
+      $implementation= 'return nameof($this)."@[\n"'.$stringOf.'."]";';
     }
+    return '/** @return string */ public function toString() { '.$implementation.' }';
   }
 }

--- a/src/main/php/module.xp
+++ b/src/main/php/module.xp
@@ -2,6 +2,7 @@
 
 use lang\mirrors\TypeMirror;
 use lang\ClassFormatException;
+use lang\DynamicClassLoader;
 
 module xp-forge/partial {
   private static $verbs= ['\\with\\', '\\is\\', '\\including\\'];
@@ -12,7 +13,8 @@ module xp-forge/partial {
    * `lang.partial.Transformation`.
    */
   public function initialize() {
-    spl_autoload_register(function($class) {
+    $loader= DynamicClassLoader::instanceFor(__CLASS__);
+    spl_autoload_register(function($class) use($loader) {
       foreach (self::$verbs as $verb) {
         if ($p= strpos($class, $verb)) {
           $cl= \xp::$cll;
@@ -27,8 +29,9 @@ module xp-forge/partial {
             } else {
               $p= strrpos($class, '\\');
               $body= $transform->constructor()->newInstance()->transform($mirror);
-              $code= 'namespace '.substr($class, 0, $p).'; trait '.substr($class, $p + 1).' { '.$body.' }';
-              eval($code);
+              $type= strtr($class, '\\', '.');
+              $loader->setClassBytes($type, 'namespace '.substr($class, 0, $p).'; trait '.substr($class, $p + 1).' { '.$body.' }');
+              $loader->loadClass0($type);
             }
           } finally {
             \xp::$cll= $cl;

--- a/src/test/php/lang/partial/unittest/Wall.class.php
+++ b/src/test/php/lang/partial/unittest/Wall.class.php
@@ -12,7 +12,14 @@ class Wall extends \lang\Object {
   use Wall\including\ToString;
   use Wall\including\Equals;
 
-  private $name, $type, $posts;
+  /** @type string */
+  private $name;
+
+  /** @type string */
+  private $type;
+
+  /** @type lang.partial.unittest.Post[] */
+  private $posts;
 
   /**
    * Constructor


### PR DESCRIPTION
This pull request adds types to all generated members:
- [x] Return types for accesors
- [x] Parameter types for constructors
- [x] Parameter and return types for generated hashCode(), toString(), equals() and compareTo()
- [x] Parameter types and "self" return type for builder methods
- [x] Return type for builder create() method

``` sh
$ xp -r lang.partial.unittest.Wall
@FileSystemCL<...\xp\partial\src\test\php\>
public class lang.partial.unittest.Wall extends lang.Object {
  private string lang.partial.unittest.Wall::$name
  private string lang.partial.unittest.Wall::$type
  private lang.partial.unittest.Post[] lang.partial.unittest.Wall::$posts

  public lang.partial.unittest.Wall __construct(string $name, string $type, lang.partial.unittest.Post[] $posts)

  public string hashCode()
  public bool equals(var $cmp)
  public string getClassName()
  public lang.XPClass getClass()
  public string toString()
  public string name()
  public string type()
  public lang.partial.unittest.Post[] posts()
}
```

_Note: The core reflection API (in contrast to xp-forge/mirrors) needs https://github.com/xp-framework/core/pull/106 merged in order for this to work!_
