### PR TITLE
Drop PHP 5.5 support, use native varargs syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: php
 sudo: false
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^7.0 | ^6.5",
     "xp-forge/mirrors": "^4.0 | ^3.0",
-    "php" : ">=5.5.0"
+    "php" : ">=5.6.0"
   },
   "require-dev" : {
     "xp-framework/unittest": "^7.0 | ^6.5"

--- a/src/main/php/lang/partial/ListIndexedBy.class.php
+++ b/src/main/php/lang/partial/ListIndexedBy.class.php
@@ -16,10 +16,10 @@ trait ListIndexedBy {
   /**
    * Constructor
    *
-   * @param  var* $elements
+   * @param  var... $elements
    */
-  public function __construct() {
-    foreach (func_get_args() as $element) {
+  public function __construct(... $elements) {
+    foreach ($elements as $element) {
       $this->indexed[$this->index($element)]= $element;
     }
   }

--- a/src/main/php/lang/partial/ListOf.class.php
+++ b/src/main/php/lang/partial/ListOf.class.php
@@ -15,10 +15,10 @@ trait ListOf {
   /**
    * Constructor
    *
-   * @param  var* $elements
+   * @param  var... $elements
    */
-  public function __construct() {
-    $this->backing= func_get_args();
+  public function __construct(... $elements) {
+    $this->backing= $elements;
   }
 
   /**


### PR DESCRIPTION
⚠️ Bumps version to 2.0.0
