### PR TITLE
XP9 Compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: php
 
 sudo: false
 
+dist: trusty
+
 php:
   - 5.6
   - 7.0

--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,12 @@
   "description" : "Partial types",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^8.0 | ^7.0 | ^6.5",
-    "xp-forge/mirrors": "^4.0 | ^3.0",
+    "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.5",
+    "xp-forge/mirrors": "^5.0 | ^4.0 | ^3.0",
     "php" : ">=5.6.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^7.0 | ^6.5"
+    "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0 | ^6.5"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/main/php/lang/partial/Builder.class.php
+++ b/src/main/php/lang/partial/Builder.class.php
@@ -7,7 +7,7 @@
  * ```php
  * use lang\partial\Builder;
  *
- * class Example extends \lang\Object {
+ * class Example {
  *   use Example\including\Builder;
  *   private $name, $id;
  *

--- a/src/main/php/lang/partial/Comparison.class.php
+++ b/src/main/php/lang/partial/Comparison.class.php
@@ -2,7 +2,7 @@
 
 use util\Comparator;
 
-class Comparison extends \lang\Object implements Comparator {
+class Comparison implements Comparator {
   private $function;
 
   /**

--- a/src/main/php/lang/partial/Constructor.class.php
+++ b/src/main/php/lang/partial/Constructor.class.php
@@ -6,7 +6,7 @@
  * ```php
  * use lang\partial\Constructor;
  *
- * class Example extends \lang\Object {
+ * class Example implements \lang\Value{
  *   use Example\including\Constructor;
  *
  *   private $firstName, $lastName;

--- a/src/main/php/lang/partial/InstanceCreationV5.class.php
+++ b/src/main/php/lang/partial/InstanceCreationV5.class.php
@@ -4,7 +4,7 @@ use lang\mirrors\TypeMirror;
 use lang\ClassLoader;
 use lang\IllegalArgumentException;
 
-abstract class InstanceCreationV5 extends \lang\Object {
+abstract class InstanceCreationV5 {
   private static $creations= [];
 
   /**

--- a/src/main/php/lang/partial/InstanceCreationV7.class.php
+++ b/src/main/php/lang/partial/InstanceCreationV7.class.php
@@ -4,7 +4,7 @@ use lang\mirrors\TypeMirror;
 use lang\ClassLoader;
 use lang\IllegalArgumentException;
 
-abstract class InstanceCreationV7 extends \lang\Object {
+abstract class InstanceCreationV7 {
   private static $creations= [];
 
   /**

--- a/src/main/php/lang/partial/Transformation.class.php
+++ b/src/main/php/lang/partial/Transformation.class.php
@@ -5,7 +5,7 @@ use lang\mirrors\Member;
 /**
  * Compile-time transformation.
  */
-abstract class Transformation extends \lang\Object {
+abstract class Transformation {
 
   /**
    * Creates trait body

--- a/src/test/php/lang/partial/unittest/Author.class.php
+++ b/src/test/php/lang/partial/unittest/Author.class.php
@@ -1,17 +1,13 @@
 <?php namespace lang\partial\unittest;
 
 use lang\partial\Accessors;
-use lang\partial\ToString;
-use lang\partial\Equals;
 use lang\partial\Builder;
 
 /**
  * Used by InstanceCreationTest
  */
-class Author extends \lang\Object {
+class Author {
   use Author\including\Accessors;
-  use Author\including\ToString;
-  use Author\including\Equals;
   use Author\including\Builder;
 
   private $name;

--- a/src/test/php/lang/partial/unittest/Book.class.php
+++ b/src/test/php/lang/partial/unittest/Book.class.php
@@ -1,18 +1,13 @@
 <?php namespace lang\partial\unittest;
 
-use util\Objects;
 use lang\partial\Accessors;
-use lang\partial\ToString;
-use lang\partial\Equals;
 use lang\partial\Builder;
 
 /**
  * Used by InstanceCreationTest
  */
-class Book extends \lang\Object {
+class Book {
   use Book\including\Accessors;
-  use Book\including\ToString;
-  use Book\including\Equals;
   use Book\including\Builder;
 
   private $name, $author, $isbn;

--- a/src/test/php/lang/partial/unittest/Comment.class.php
+++ b/src/test/php/lang/partial/unittest/Comment.class.php
@@ -2,12 +2,14 @@
 
 use util\Date;
 use lang\partial\Accessors;
+use lang\partial\ToString;
 
 /**
  * Used as fixture in the "ValueObjectTest" class
  */
 class Comment {
   use Comment\including\Accessors;
+  use Comment\including\ToString;
 
   private $author, $text, $date;
 

--- a/src/test/php/lang/partial/unittest/Comment.class.php
+++ b/src/test/php/lang/partial/unittest/Comment.class.php
@@ -2,16 +2,12 @@
 
 use util\Date;
 use lang\partial\Accessors;
-use lang\partial\ToString;
-use lang\partial\Equals;
 
 /**
  * Used as fixture in the "ValueObjectTest" class
  */
-class Comment extends \lang\Object {
+class Comment {
   use Comment\including\Accessors;
-  use Comment\including\ToString;
-  use Comment\including\Equals;
 
   private $author, $text, $date;
 

--- a/src/test/php/lang/partial/unittest/Entity.class.php
+++ b/src/test/php/lang/partial/unittest/Entity.class.php
@@ -3,5 +3,5 @@
 /**
  * Used by InstanceCreationTest
  */
-abstract class Entity extends \lang\Object {
+abstract class Entity implements \lang\Value {
 }

--- a/src/test/php/lang/partial/unittest/Event.class.php
+++ b/src/test/php/lang/partial/unittest/Event.class.php
@@ -1,13 +1,12 @@
 <?php namespace lang\partial\unittest;
 
-use util\Objects;
 use lang\partial\Accessors;
 use lang\partial\Builder;
 
 /**
  * Used by InstanceCreationTest
  */
-class Event extends \lang\Object {
+class Event {
   use Event\including\Accessors;
   use Event\including\Builder;
 

--- a/src/test/php/lang/partial/unittest/Isbn.class.php
+++ b/src/test/php/lang/partial/unittest/Isbn.class.php
@@ -1,19 +1,18 @@
 <?php namespace lang\partial\unittest;
 
+use util\Objects;
 use lang\partial\Accessors;
-use lang\partial\ToString;
-use lang\partial\Equals;
+use lang\partial\Value;
 use lang\partial\Builder;
 
 /**
  * Used by InstanceCreationTest
  */
-class Isbn extends \lang\Object {
+class Isbn implements \lang\Value {
   const EAN13 = 13;
 
+  use Isbn\is\Value;
   use Isbn\including\Accessors;
-  use Isbn\including\ToString;
-  use Isbn\including\Equals;
   use Isbn\including\Builder;
 
   private $number, $type;
@@ -36,12 +35,15 @@ class Isbn extends \lang\Object {
   public function type() { return $this->type; }
 
   /**
-   * Returns whether a given value equals this instance
+   * Overwritten comparison method
    *
    * @param  var $value
-   * @return bool
+   * @return int
    */
-  public function equals($value) {
-    return $value instanceof self && $this->number === $value->number && $this->type === $value->type;
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare([$this->number, $this->type], [$value->number, $value->type])
+      : 1
+    ;
   }
 }

--- a/src/test/php/lang/partial/unittest/Named.class.php
+++ b/src/test/php/lang/partial/unittest/Named.class.php
@@ -5,7 +5,7 @@ use lang\partial\Box;
 /**
  * Used as fixture in the "BoxTest" and "CompareToTest" classes
  */
-class Named extends \lang\Object implements \lang\Value {
+class Named implements \lang\Value {
   use Named\is\Box { value as name; }
 
   /** @return bool */

--- a/src/test/php/lang/partial/unittest/Person.class.php
+++ b/src/test/php/lang/partial/unittest/Person.class.php
@@ -2,7 +2,7 @@
 
 use lang\partial\Accessors;
 use lang\partial\ToString;
-use lang\partial\Equals;
+use lang\partial\HashCode;
 use lang\partial\Constructor;
 use lang\partial\CompareTo;
 use lang\partial\Comparators;
@@ -10,10 +10,10 @@ use lang\partial\Comparators;
 /**
  * Used by CompareToTest
  */
-class Person extends \lang\Object {
+class Person implements \lang\Value {
   use Person\including\Accessors;
   use Person\including\ToString;
-  use Person\including\Equals;
+  use Person\including\HashCode;
   use Person\including\Constructor;
   use Person\including\CompareTo;
   use Person\including\Comparators {

--- a/src/test/php/lang/partial/unittest/Post.class.php
+++ b/src/test/php/lang/partial/unittest/Post.class.php
@@ -2,17 +2,13 @@
 
 use util\Date;
 use lang\partial\Accessors;
-use lang\partial\ToString;
-use lang\partial\Equals;
 use lang\partial\Comparators;
 
 /**
  * Used as fixture in the "ValueObjectTest" class
  */
-class Post extends \lang\Object {
+class Post {
   use Post\including\Accessors;
-  use Post\including\ToString;
-  use Post\including\Equals;
   use Post\including\Comparators;
 
   private $author, $text, $date;

--- a/src/test/php/lang/partial/unittest/Tests.class.php
+++ b/src/test/php/lang/partial/unittest/Tests.class.php
@@ -5,7 +5,7 @@ use lang\partial\ListIndexedBy;
 /**
  * Used as fixture in the "ListIndexedByTest" class
  */
-class Tests extends \lang\Object implements \IteratorAggregate {
+class Tests implements \IteratorAggregate {
   use Tests\is\ListIndexedBy;
 
   /**

--- a/src/test/php/lang/partial/unittest/TypeTest.class.php
+++ b/src/test/php/lang/partial/unittest/TypeTest.class.php
@@ -1,0 +1,109 @@
+<?php namespace lang\partial\unittest;
+
+use lang\mirrors\TypeMirror;
+use lang\partial\InstanceCreation;
+use lang\Value;
+use lang\Primitive;
+use lang\XPClass;
+use lang\Type;
+use lang\ArrayType;
+
+class TypeTest extends PartialTest {
+  private $fixture;
+
+  /** @return void */
+  public function setUp() {
+    $this->fixture= new TypeMirror($this->declareType([Value::class], '{
+      use <T>\is\lang\partial\Value;
+      use <T>\with\lang\partial\Equals;
+      use <T>\with\lang\partial\Builder;
+
+      /** @type int */
+      private $id;
+
+      /** @type lang.partial.unittest.Named */
+      private $name;
+
+      /** @type string[] */
+      private $skills;
+    }'));
+  }
+
+  #[@test]
+  public function primitive_accessor() {
+    $this->assertEquals(Primitive::$INT, $this->fixture->methods()->named('id')->returns());
+  }
+
+  #[@test]
+  public function primitive_parameter() {
+    $this->assertEquals(Primitive::$INT, $this->fixture->constructor()->parameters()->named('id')->type());
+  }
+
+  #[@test]
+  public function primitive_builder() {
+    $this->assertEquals(Primitive::$INT, (new TypeMirror(InstanceCreation::typeOf($this->fixture)))->methods()->named('id')->parameters()->first()->type());
+  }
+
+  #[@test]
+  public function object_accessor() {
+    $this->assertEquals(new XPClass(Named::class), $this->fixture->methods()->named('name')->returns());
+  }
+
+  #[@test]
+  public function object_parameter() {
+    $this->assertEquals(new XPClass(Named::class), $this->fixture->constructor()->parameters()->named('name')->type());
+  }
+
+  #[@test]
+  public function object_builder() {
+    $this->assertEquals(new XPClass(Named::class), (new TypeMirror(InstanceCreation::typeOf($this->fixture)))->methods()->named('name')->parameters()->first()->type());
+  }
+
+  #[@test]
+  public function array_accessor() {
+    $this->assertEquals(new ArrayType(Primitive::$STRING), $this->fixture->methods()->named('skills')->returns());
+  }
+
+  #[@test]
+  public function array_parameter() {
+    $this->assertEquals(new ArrayType(Primitive::$STRING), $this->fixture->constructor()->parameters()->named('skills')->type());
+  }
+
+  #[@test]
+  public function array_builder() {
+    $this->assertEquals(new ArrayType(Primitive::$STRING), (new TypeMirror(InstanceCreation::typeOf($this->fixture)))->methods()->named('skills')->parameters()->first()->type());
+  }
+
+  #[@test]
+  public function builder() {
+    $this->assertEquals(XPClass::forName($this->fixture->name()), (new TypeMirror(InstanceCreation::typeOf($this->fixture)))->methods()->named('create')->returns());
+  }
+
+  #[@test]
+  public function hashCode_type() {
+    $this->assertEquals(Primitive::$STRING, $this->fixture->methods()->named('hashCode')->returns());
+  }
+
+  #[@test]
+  public function toString_type() {
+    $this->assertEquals(Primitive::$STRING, $this->fixture->methods()->named('hashCode')->returns());
+  }
+
+  #[@test]
+  public function compareTo_types() {
+    $compareTo= $this->fixture->methods()->named('compareTo');
+    $this->assertEquals(
+      [Type::$VAR, Primitive::$INT],
+      [$compareTo->parameters()->first()->type(), $compareTo->returns()]
+    );
+  }
+
+  #[@test]
+  public function equals_types() {
+    $compareTo= $this->fixture->methods()->named('equals');
+    $this->assertEquals(
+      [Type::$VAR, Primitive::$BOOL],
+      [$compareTo->parameters()->first()->type(), $compareTo->returns()]
+    );
+  }
+}

--- a/src/test/php/lang/partial/unittest/ValueObjectTest.class.php
+++ b/src/test/php/lang/partial/unittest/ValueObjectTest.class.php
@@ -43,7 +43,7 @@ class ValueObjectTest extends \unittest\TestCase {
   #[@test]
   public function string_of() {
     $this->assertEquals(
-      "lang.partial.unittest.Wall@[\n  name => \"A\"\n  type => \"open\"\n  posts => [\n  ]\n]",
+      "lang.partial.unittest.Wall@[\n  name => \"A\"\n  type => \"open\"\n  posts => []\n]",
       (new Wall('A', 'open', []))->toString()
     );
   }

--- a/src/test/php/lang/partial/unittest/ValueObjectTest.class.php
+++ b/src/test/php/lang/partial/unittest/ValueObjectTest.class.php
@@ -42,9 +42,10 @@ class ValueObjectTest extends \unittest\TestCase {
 
   #[@test]
   public function string_of() {
+    $date= Date::now();
     $this->assertEquals(
-      "lang.partial.unittest.Wall@[\n  name => \"A\"\n  type => \"open\"\n  posts => []\n]",
-      (new Wall('A', 'open', []))->toString()
+      "lang.partial.unittest.Comment@[\n  author => \"Tester\"\n  text => \"Test\"\n  date => ".$date->toString()."\n]",
+      (new Comment('Tester', 'Test', $date))->toString()
     );
   }
 

--- a/src/test/php/lang/partial/unittest/Wall.class.php
+++ b/src/test/php/lang/partial/unittest/Wall.class.php
@@ -2,15 +2,13 @@
 
 use lang\partial\Accessors;
 use lang\partial\ToString;
-use lang\partial\Equals;
 
 /**
  * Used as fixture in the "AccessorsTest" class
  */
-class Wall extends \lang\Object {
-  use Wall\including\Accessors;
+class Wall {
   use Wall\including\ToString;
-  use Wall\including\Equals;
+  use Wall\including\Accessors;
 
   /** @type string */
   private $name;

--- a/src/test/php/lang/partial/unittest/Walls.class.php
+++ b/src/test/php/lang/partial/unittest/Walls.class.php
@@ -5,6 +5,6 @@ use lang\partial\ListOf;
 /**
  * Used as fixture in the "ListOfTest" class
  */
-class Walls extends \lang\Object implements \IteratorAggregate {
+class Walls implements \IteratorAggregate {
   use Walls\is\ListOf;
 }


### PR DESCRIPTION
This pull request adds compatibility with XP9 by implementing `lang.Value` instead of extending `lang.Object` and changing one test to work with both XP8 and XP9's `Objects::stringOf()` (see xp-framework/rfc#324)